### PR TITLE
Link libzstd

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,6 +15,7 @@ fn main() {
     generate_simavr_bindings(&out_path);
     link_libelf();
     link_zlib();
+    link_libzstd();
 }
 
 fn build_simavr(out: &Path) {
@@ -123,4 +124,11 @@ fn link_zlib() {
     pkg_config::probe_library("zlib").unwrap();
 
     println!("cargo:rustc-link-lib=z");
+}
+
+fn link_libzstd() {
+    println!("=> Linking libzstd");
+
+    pkg_config::probe_library("libzstd").unwrap();
+    println!("cargo-rustc-link-lib=zstd");
 }


### PR DESCRIPTION
On a recent system, linking suddenly stopped working, with errors like
```
in function `__libelf_compress':
          (.text+0xf9): undefined reference to `ZSTD_createCCtx'
          /usr/bin/ld: (.text+0x263): undefined reference to `ZSTD_compressStream2'
          /usr/bin/ld: (.text+0x26e): undefined reference to `ZSTD_isError'
          /usr/bin/ld: (.text+0x292): undefined reference to `ZSTD_freeCCtx'
          /usr/bin/ld: (.text+0x527): undefined reference to `ZSTD_compressStream2'
          /usr/bin/ld: (.text+0x532): undefined reference to `ZSTD_isError'
          /usr/bin/ld: (.text+0x711): undefined reference to `ZSTD_freeCCtx'
...
```

Linking against `libzstd` solves the issue.

I suppose this error affects all builds involving `libelf >= 0.189`, which introduced libzstd support ([release notes](https://sourceware.org/pipermail/elfutils-devel/2023q1/006023.html)).
