### PR TITLE
Use TARGET Env Var in build.rs to Fix Type Mismatch on 64-bit Systems

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -144,7 +144,11 @@ fn generate_bindings(out: &Path) {
         builder = builder.header(header);
     }
 
+    let target = std::env::var("TARGET").expect("TARGET env var not set");
+    println!(" => Target: {}", target);
     let bindings = builder
+        .clang_arg("-target")
+        .clang_arg(&target) // Ensure 64-bit target
         .generate()
         .expect("Couldn't generate simavr's bindings");
 


### PR DESCRIPTION
### Summary
This PR fixes a compilation error in `simavr-ffi` where the generated `bindings.rs` attempts an invalid `std::mem::transmute` from `u64` to `u32` on 64-bit systems (see issue #6). The root cause is that `bindgen` doesn’t align type sizes with the target architecture, leading to size mismatches.

### Changes
- Modified `build.rs` to pass the Cargo `TARGET` environment variable to `bindgen` via `clang_arg`

This ensures the generated bindings respect the target platform’s architecture (e.g., x86_64-unknown-linux-gnu, aarch64-apple-darwin), fixing type mismatches dynamically.

Impact

Resolves error[E0512]: cannot transmute between types of different sizes on 64-bit Linux (tested on Pop!_OS 24.04 LTS, Rust 1.70.0).
Portable across platforms (e.g., macOS, 32-bit Linux) since it uses the build target rather than hardcoding.
No breaking changes expected for existing users—only improves compatibility.

Testing

Built and tested locally on x86_64 Linux with cargo build --release and cargo test.
Confirmed the error no longer occurs, and bindings generate correct type sizes.

Related Issue
Closes #6

Notes

Assumes TARGET is always set by Cargo, which is standard during builds.
